### PR TITLE
feat(image-picker): delimiting mimetypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kosmos-ui",
-  "version": "6.9.2",
+  "version": "6.9.3",
   "author": "Clemente Sutil",
   "license": "ISC",
   "description": "React components UI library written in Typescript.",

--- a/src/components/ImagePicker/index.tsx
+++ b/src/components/ImagePicker/index.tsx
@@ -47,7 +47,7 @@ function ImagePicker({
       onDropRejected && onDropRejected(event);
     },
     ...options,
-    accept: "image/*",
+    accept: ["image/jpeg", "image/png"],
     multiple: false,
   });
 


### PR DESCRIPTION
Delimiting mime-type of images, 'cause we are accepting images like .heic which cannot be rendered in grafito